### PR TITLE
use callback to create net.Listener

### DIFF
--- a/ssh.go
+++ b/ssh.go
@@ -2,6 +2,7 @@ package ssh
 
 import (
 	"crypto/subtle"
+	"errors"
 	"net"
 
 	gossh "golang.org/x/crypto/ssh"
@@ -28,6 +29,9 @@ const (
 
 // DefaultHandler is the default Handler used by Serve.
 var DefaultHandler Handler
+
+// ErrReject is returned by some callbacks to reject a request.
+var ErrRejected = errors.New("rejected")
 
 // Option is a functional option handler for Server.
 type Option func(*Server) error
@@ -69,8 +73,9 @@ type ReversePortForwardingCallback func(ctx Context, bindHost string, bindPort u
 type LocalUnixForwardingCallback func(ctx Context, socketPath string) bool
 
 // ReverseUnixForwardingCallback is a hook for allowing reverse unix forwarding
-// (streamlocal-forward@openssh.com).
-type ReverseUnixForwardingCallback func(ctx Context, socketPath string) func(socketPath string) (net.Listener, error)
+// (streamlocal-forward@openssh.com). Returning ErrRejected will reject the
+// request.
+type ReverseUnixForwardingCallback func(ctx Context, socketPath string) (net.Listener, error)
 
 // ServerConfigCallback is a hook for creating custom default server configs
 type ServerConfigCallback func(ctx Context) *gossh.ServerConfig

--- a/ssh.go
+++ b/ssh.go
@@ -70,7 +70,7 @@ type LocalUnixForwardingCallback func(ctx Context, socketPath string) bool
 
 // ReverseUnixForwardingCallback is a hook for allowing reverse unix forwarding
 // (streamlocal-forward@openssh.com).
-type ReverseUnixForwardingCallback func(ctx Context, socketPath string) func() (net.Listener, error)
+type ReverseUnixForwardingCallback func(ctx Context, socketPath string) func(socketPath string) (net.Listener, error)
 
 // ServerConfigCallback is a hook for creating custom default server configs
 type ServerConfigCallback func(ctx Context) *gossh.ServerConfig

--- a/ssh.go
+++ b/ssh.go
@@ -70,7 +70,7 @@ type LocalUnixForwardingCallback func(ctx Context, socketPath string) bool
 
 // ReverseUnixForwardingCallback is a hook for allowing reverse unix forwarding
 // (streamlocal-forward@openssh.com).
-type ReverseUnixForwardingCallback func(ctx Context, socketPath string) bool
+type ReverseUnixForwardingCallback func(ctx Context, socketPath string) func() (net.Listener, error)
 
 // ServerConfigCallback is a hook for creating custom default server configs
 type ServerConfigCallback func(ctx Context) *gossh.ServerConfig

--- a/streamlocal.go
+++ b/streamlocal.go
@@ -110,7 +110,7 @@ func (h *ForwardedUnixHandler) HandleSSHRequest(ctx Context, srv *Server, req *g
 			return false, nil
 		}
 
-		if srv.ReverseUnixForwardingCallback == nil || !srv.ReverseUnixForwardingCallback(ctx, reqPayload.SocketPath) {
+		if srv.ReverseUnixForwardingCallback == nil || srv.ReverseUnixForwardingCallback(ctx, reqPayload.SocketPath) == nil {
 			return false, []byte("unix forwarding is disabled")
 		}
 
@@ -141,7 +141,7 @@ func (h *ForwardedUnixHandler) HandleSSHRequest(ctx Context, srv *Server, req *g
 			return false, nil
 		}
 
-		ln, err := net.Listen("unix", addr)
+		ln, err := srv.ReverseUnixForwardingCallback(ctx, reqPayload.SocketPath)()
 		if err != nil {
 			// TODO: log unix listen failure
 			return false, nil

--- a/streamlocal_test.go
+++ b/streamlocal_test.go
@@ -127,11 +127,11 @@ func TestReverseUnixForwardingWorks(t *testing.T) {
 
 	_, client, cleanup := newTestSession(t, &Server{
 		Handler: func(s Session) {},
-		ReverseUnixForwardingCallback: func(ctx Context, socketPath string) bool {
+		ReverseUnixForwardingCallback: func(ctx Context, socketPath string) (net.Listener, error) {
 			if socketPath != remoteSocketPath {
 				panic("unexpected socket path: " + socketPath)
 			}
-			return true
+			return SimpleUnixReverseForwardingCallback(ctx, socketPath)
 		},
 	}, nil)
 	defer cleanup()
@@ -182,12 +182,12 @@ func TestReverseUnixForwardingRespectsCallback(t *testing.T) {
 	var called int64
 	_, client, cleanup := newTestSession(t, &Server{
 		Handler: func(s Session) {},
-		ReverseUnixForwardingCallback: func(ctx Context, socketPath string) bool {
+		ReverseUnixForwardingCallback: func(ctx Context, socketPath string) (net.Listener, error) {
 			atomic.AddInt64(&called, 1)
 			if socketPath != remoteSocketPath {
 				panic("unexpected socket path: " + socketPath)
 			}
-			return false
+			return nil, ErrRejected
 		},
 	}, nil)
 	defer cleanup()


### PR DESCRIPTION
```go
		ReverseUnixForwardingCallback: ssh.ReverseUnixForwardingCallback(func(ctx ssh.Context, socketPath string) func() (net.Listener, error) {
			isAllowed := true

			if isAllowed {
				return ssh.DefaultSocketListener
			}

			return nil
		}),
```
**OR**
```go
ReverseUnixForwardingCallback: ssh.ReverseUnixForwardingCallback(func(ctx ssh.Context, socketPath string) func() (net.Listener, error) {
			isAllowed := true

			if isAllowed {
				return func(socketPath string) (net.Listener, error) {
					ln, err := ssh.DefaultSocketListener(socketPath)
					if err != nil {
						return nil, err
					}

					if err := os.Chmod(socketPath, os.FileMode(0777)); err != nil {
						return nil, err
					}

					return ln, nil
				}
			}

			return nil
		}),
```